### PR TITLE
Add JSON tags for Report struct

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -24,8 +24,8 @@ type Report struct {
 	Title     *string
 	Owner     *string
 	Zone      *int64
-	StartTime *int64
-	EndTime   *int64
+  StartTime *int64 `json:"start"`
+  EndTime   *int64 `json:"end"`
 }
 
 type Fight struct {


### PR DESCRIPTION
Hello,

Thank you for this nice package. I use it for a Discord bot. While I was trying to get the information about the last reports I noticed that I couldn't get the unixtime as described on the warcraftlogs API documentation. I tried to convert it and was running into multiple errors. 
After I looked into the API call to see if it is in the JSON I looked into your package. 
After adding the JSON tags for the Report struct the Object contains the right values and I can convert it to UTC.

This is at the same time an issue report and and a solving PR.

Regards Peuserik

**Add JSON tags for Report struct**
* to fix empty and/or nil object
 